### PR TITLE
Add ManagedClusterAddon CRD

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -88,6 +88,7 @@ case "$CLUSTER" in
     oc adm inspect multiclusterobservabilities.observability.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect managedclusteraddons.addon.open-cluster-management.io  --all-namespaces  --dest-dir=must-gather
     oc adm inspect ns/open-cluster-management-observability --dest-dir=must-gather
+    oc adm inspect ns/open-cluster-management-addon-observability --dest-dir=must-gather
 
     ;;
 


### PR DESCRIPTION
This Pull Request adds the managedclusteraddon CRD and the open-cluster-management-addon-observability namespace to the list of resources collected in the hub. 

See Related Issue: https://github.com/open-cluster-management/backlog/issues/5815
