### PR TITLE
add discovery components to must-gather; tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ If we take a look at the cluster-manager POD for example you will see the yaml f
 - clusterinfos.internal.open-cluster-management.io
 - hubcores.nucleus.open-cluster-management.io
 - spokecores.nucleus.open-cluster-management.io
+- discoveredclusterrefreshes.discovery.open-cluster-management.io
+- discoveredclusters.discovery.open-cluster-management.io
+- discoveryconfigs.discovery.open-cluster-management.io
 
 ### If run on Managed Cluster, it collects (is being updated soon to match New APIs):
 

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -90,6 +90,10 @@ case "$CLUSTER" in
     oc adm inspect ns/open-cluster-management-observability --dest-dir=must-gather
     oc adm inspect ns/open-cluster-management-addon-observability --dest-dir=must-gather
 
+    oc adm inspect  discoveredclusterrefreshes.discovery.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+    oc adm inspect  discoveredclusters.discovery.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+    oc adm inspect  discoveryconfigs.discovery.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+
     ;;
 
       


### PR DESCRIPTION
Must-gather should include the new discovery objects created as part of Discovery work.

These objects are not yet part of the ACM composite build. We plan on integrating them as part of 2.2 Sprint 1.

Even if these component types don't exist on a cluster, the gather script just says "can't find these" and moves on; I believe it's safe to merge these changes before the full integration of the discovery components.

Related Sprint 1 Task: https://app.zenhub.com/workspaces/applifecycle-issue-tracker-5e480a1f17e47394a67447b9/issues/open-cluster-management/backlog/6923
