### PR TITLE
gather local-cluster on hub

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -110,6 +110,7 @@ case "$CLUSTER" in
     oc adm inspect observabilityaddons.observability.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect multiclusterobservabilities.observability.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect managedclusteraddons.addon.open-cluster-management.io  --all-namespaces  --dest-dir=must-gather
+    oc adm inspect ns/open-cluster-management-observability --dest-dir=must-gather
     oc adm inspect observatoria.core.observatorium.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect ns/open-cluster-management-addon-observability --dest-dir=must-gather
 


### PR DESCRIPTION
This PR adds collection for resources in local cluster. This is accomplished by refactoring spoke collection logic into a separate method, and calling this method with the hub collection logic. See conversation for rationale/logic. 