### PR TITLE
Add inspect for openshift-monitoring namespace

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -59,7 +59,6 @@ gather_spoke () {
     oc adm inspect ns/openshift-gatekeeper-system --dest-dir=must-gather
     oc adm inspect ns/openshift-gatekeeper-operator --dest-dir=must-gather
 
-    oc adm inspect ns/openshift-monitoring --dest-dir=must-gather
 }
 
 check_if_hub
@@ -121,6 +120,8 @@ case "$CLUSTER" in
     oc adm inspect  discoveryconfigs.discovery.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect searchoperators.search.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect searchcustomizations.search.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+
+    oc adm inspect ns/openshift-monitoring --dest-dir=must-gather
     
     # gather hub imported as managed
     gather_spoke


### PR DESCRIPTION
Adding `oc adm inspect ns/openshift-monitoring` to the gather script so we can get information to debug the Prometheus error in some canary builds.  See https://github.com/open-cluster-management/backlog/issues/8564