### PR TITLE
Add inspect for openshift-monitoring namespace

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -119,6 +119,8 @@ case "$CLUSTER" in
     oc adm inspect  discoveryconfigs.discovery.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect searchoperators.search.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect searchcustomizations.search.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+
+    oc adm inspect ns/openshift-monitoring  --dest-dir=must-gather
     
     # gather hub imported as managed
     gather_spoke


### PR DESCRIPTION
Adding `oc adm inspect ns/openshift-monitoring` to the hub must gather to help debug a Prometheus issue that occurs in some canary builds.  See https://github.com/open-cluster-management/backlog/issues/8564