### PR TITLE
Add ns/open-cluster-management-addon-observability to Managed Cluster collection

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -53,9 +53,10 @@ gather_spoke () {
     oc adm inspect certificatepolicies.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect iampolicies.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect cispolicies.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
-
-    oc adm inspect ns/open-cluster-management-observability --dest-dir=must-gather
     
+    oc adm inspect ns/open-cluster-management-observability --dest-dir=must-gather
+    oc adm inspect ns/open-cluster-management-addon-observability --dest-dir=must-gather
+
     oc adm inspect ns/openshift-gatekeeper-system --dest-dir=must-gather
     oc adm inspect ns/openshift-gatekeeper-operator --dest-dir=must-gather
 }


### PR DESCRIPTION
We are missing must gather information for metrics-collector and endpoint-operator. Previously these pods were in a separate namespace, now they are in open-cluster-management-addon-observability. Adding this new namespace and keeping the old one for backwards compatibility.


Related Issue: https://github.com/open-cluster-management/backlog/issues/9143