### PR TITLE
Add Subscriptions and HelmReleases to Managed Cluster Collection

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -125,6 +125,7 @@ case "$CLUSTER" in
     oc adm inspect searchcustomizations.search.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
 
     oc adm inspect ns/openshift-monitoring  --dest-dir=must-gather
+    oc adm inspect ns/open-cluster-management-issuer  --dest-dir=must-gather
     
     # gather hub imported as managed
     gather_spoke


### PR DESCRIPTION
Adding additional resources to must gather collection script as requested in issue [9252](https://github.com/open-cluster-management/backlog/issues/9252#issuecomment-775369918)

PlacementRule, Channel and Subscription are already captured on the hub. This pull request adds subscriptions and helmreleases to the spoke collection. 

(this PR also adds a namespace to collect, `open-cluster-management-issuer`, new as of 2.3)