### PR TITLE
Collect PolicySet CRs on hub

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -105,6 +105,7 @@ case "$CLUSTER" in
     oc adm inspect placementrules.apps.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect subscriptions.apps.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect policies.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+    oc adm inspect policysets.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect policyautomations.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect placementbindings.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect clusterdeployments.hive.openshift.io --all-namespaces  --dest-dir=must-gather


### PR DESCRIPTION
**Related Issue:**  https://github.com/stolostron/backlog/issues/18398

**Description of Changes:**
PolicySet CRD is introduced in ACM 2.5 and we need to collect CRs for it for troubleshooting

**What resource is being added**: 
policysets.policy.open-cluster-management.io

**Is this a Hub or Managed cluster change?:** 
Hub Cluster

**Notes:**

Signed-off-by: Yu Cao <ycao@redhat.com>