### PR TITLE
We should collect the AnsibleJob resources since ACM creates them

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -148,6 +148,7 @@ case "$CLUSTER" in
     oc adm inspect backups.velero.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect restores.velero.io --all-namespaces  --dest-dir=must-gather
 
+    oc adm inspect ansiblejobs.tower.ansible.com --all-namespaces  --dest-dir=must-gather
     
     # gather hub imported as managed
     gather_spoke


### PR DESCRIPTION
The `AnsibleJob` resources contain valuable status about automation.
Our product shows this status information so I think it's important
we include this in must gather.  Note that I am not attempting to
gather the job logs from the automation.  For now I'm not sure that is
something we want to collect.

Refs:
 - https://github.com/stolostron/backlog/issues/20158

Signed-off-by: Gus Parvin <gparvin@redhat.com>

**Related Issue:**  open-cluster-management/backlog#20158

**Description of Changes:**
Provided above

**What resource is being added**: 
`AnsibleJob`

**Is this a Hub or Managed cluster change?:** 
Hub Cluster | Managed Cluster
`Hub`

**Notes:**

