### PR TITLE
must-gather: cleanup ramen resources

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -29,34 +29,32 @@ check_managed_clusters() {
 }
 
 collect_dr_logs() {
+    mkdir -p ${BASE_COLLECTION_PATH}/Ramen_resources
     # Collect logs for oc get mirrorpeers
-        echo "collecting oc command get mirrorpeers" >> ${BASE_COLLECTION_PATH}/gather-managed.log
-        COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/get_mirrorpeers
-        oc get mirrorpeers >> ${COMMAND_OUTPUT_FILE}
+    COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/Ramen_resources/get_mirrorpeers
+    oc get mirrorpeers >> ${COMMAND_OUTPUT_FILE}
     # Collect logs for oc get drpolicy
-        echo "collecting oc command get drpolicy" >> ${BASE_COLLECTION_PATH}/gather-managed.log
-        COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/cluster-scoped-resources/oc_output/get_drpolicy
-        oc get drpolicy >> ${COMMAND_OUTPUT_FILE}
-        # Collect logs for oc describe drpolicy
-        echo "collecting oc command describe drpolicy" >> ${BASE_COLLECTION_PATH}/gather-managed.log
-        COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/desc_drpolicy
-        oc describe drpolicy >> ${COMMAND_OUTPUT_FILE}
-        oc adm --dest-dir=must-gather inspect drpolicy
-        # For Channels of all namespaces
-        oc get channel --all-namespaces >> ${BASE_COLLECTION_PATH}/channel_all_namespace
-        oc adm --dest-dir=must-gather inspect channel --all-namespaces
-        # For DRPlacementControl of all namespaces
-        oc get drplacementcontrol --all-namespaces >> ${BASE_COLLECTION_PATH}/drplacementcontrol_all_namespaces
-        oc adm --dest-dir=must-gather inspect drplacementcontrol --all-namespaces
-        # For placement rule of all namespaces
-        oc get placementrule --all-namespaces >> ${BASE_COLLECTION_PATH}/placementrule_all_namespaces
-        oc adm --dest-dir=must-gather inspect placementrule --all-namespaces
-        # For subscription of all namespaces
-        oc get subscription --all-namespaces >> ${BASE_COLLECTION_PATH}/subscription_all_namespaces
-        oc adm --dest-dir=must-gather inspect subscription --all-namespaces
-        # For ManagedClusterAddons of all namespaces
-        oc get managedclusteraddons --all-namespaces >> ${BASE_COLLECTION_PATH}/managedclusteraddons_all_namespaces
-        oc adm --dest-dir=must-gather inspect managedclusteraddons --all-namespaces
+    COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/Ramen_resources/get_drpolicy
+    oc get drpolicy >> ${COMMAND_OUTPUT_FILE}
+    # Collect logs for oc describe drpolicy
+    COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/Ramen_resources/desc_drpolicy
+    oc describe drpolicy >> ${COMMAND_OUTPUT_FILE}
+    oc adm --dest-dir=must-gather inspect drpolicy
+    # For Channels of all namespaces
+    oc get channel --all-namespaces >> ${BASE_COLLECTION_PATH}/Ramen_resources/channel_all_namespace
+    oc adm --dest-dir=must-gather inspect channel --all-namespaces
+    # For DRPlacementControl of all namespaces
+    oc get drplacementcontrol --all-namespaces >> ${BASE_COLLECTION_PATH}/Ramen_resources/drplacementcontrol_all_namespaces
+    oc adm --dest-dir=must-gather inspect drplacementcontrol --all-namespaces
+    # For placement rule of all namespaces
+    oc get placementrule --all-namespaces >> ${BASE_COLLECTION_PATH}/Ramen_resources/placementrule_all_namespaces
+    oc adm --dest-dir=must-gather inspect placementrule --all-namespaces
+    # For subscription of all namespaces
+    oc get subscription --all-namespaces >> ${BASE_COLLECTION_PATH}/Ramen_resources/subscription_all_namespaces
+    oc adm --dest-dir=must-gather inspect subscription --all-namespaces
+    # For ManagedClusterAddons of all namespaces
+    oc get managedclusteraddons --all-namespaces >> ${BASE_COLLECTION_PATH}/Ramen_resources/managedclusteraddons_all_namespaces
+    oc adm --dest-dir=must-gather inspect managedclusteraddons --all-namespaces
 }
 
 check_if_hub () {


### PR DESCRIPTION
This commit adds some cleanup to the
Ramen resources.
1. Collects all the resources in seperate
directory
2. improves indendation

Signed-off-by: yati1998 <ypadia@redhat.com>

**Related Issue:**  open-cluster-management/backlog#<ISSUE_NUMBER>

**Description of Changes:**

**What resource is being added**: 

**Is this a Hub or Managed cluster change?:** 
Hub Cluster | Managed Cluster

**Notes:**

