### PR TITLE
Update org name to stolostron in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
--include $(shell curl -H 'Authorization: token ${GITHUB_TOKEN}' -H 'Accept: application/vnd.github.v4.raw' -L https://api.github.com/repos/open-cluster-management/build-harness-extensions/contents/templates/Makefile.build-harness-bootstrap -o .build-harness-bootstrap; echo .build-harness-bootstrap)
-
+-include $(shell curl -H 'Authorization: token ${GITHUB_TOKEN}' -H 'Accept: application/vnd.github.v4.raw' -L https://api.github.com/repos/stolostron/build-harness-extensions/contents/templates/Makefile.build-harness-bootstrap -o .build-harness-bootstrap; echo .build-harness-bootstrap)


### PR DESCRIPTION
`curl` for `build-harness-extensions` in Makefile still uses the
`open-cluster-management` org name. Update to `stolostron` to ensure
`curl` still functions properly should the url ever return a 404
instead of redirecting, which is the current behavior.

Signed-off-by: Patrick Hickey <pahickey@redhat.com>

**Notes:**
Propagation to other branches may be necessary