### PR TITLE
Remediate package vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ FROM quay.io/openshift/origin-cli:4.7 as builder
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN microdnf update -y \
-    && microdnf install -y tar rsync findutils gzip iproute util-linux \
     && microdnf clean all
 
 # Copy oc binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ FROM quay.io/openshift/origin-cli:4.7 as builder
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN microdnf update -y \
-    && microdnf clean all
-
 # Copy oc binary
 COPY --from=builder /usr/bin/oc /usr/bin/oc
 

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -6,7 +6,6 @@ FROM registry.ci.openshift.org/ocp/4.7:cli AS builder
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN microdnf update -y \
-    && microdnf install -y tar rsync findutils gzip iproute util-linux \
     && microdnf clean all
 
 # Copy oc binary

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -5,9 +5,6 @@ FROM registry.ci.openshift.org/ocp/4.7:cli AS builder
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN microdnf update -y \
-    && microdnf clean all
-
 # Copy oc binary
 COPY --from=builder /usr/bin/oc /usr/bin/oc
 

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -5,6 +5,9 @@ FROM registry.ci.openshift.org/ocp/4.7:cli AS builder
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
+RUN microdnf update -y \
+    && microdnf install -y tar rsync findutils gzip iproute util-linux \
+    && microdnf clean all
 
 # Copy oc binary
 COPY --from=builder /usr/bin/oc /usr/bin/oc


### PR DESCRIPTION
**Related Issue:**  open-cluster-management/backlog#20401

**Description of Changes:**
Add microdnf update to dockerfile.prow. We've detected different package vulnerabilites in the images being scanned, and my guess is that it's because we don't run microdnf update in the dockerfilee used in prow

**What resource is being added**: No resource is being added


**Is this a Hub or Managed cluster change?:** Image change
Hub Cluster | Managed Cluster 

**Notes:**


