### PR TITLE
managedcluster details are empty

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -63,7 +63,7 @@ collect_dr_logs() {
     oc adm --dest-dir=must-gather inspect managedclusteraddons --all-namespaces
 
     MANAGEDCLUSTERS=`oc get managedcluster --no-headers=true | awk '{ print $1 }'`
-    for managedcluster in MANAGEDCLUSTERS; do
+    for managedcluster in ${MANAGEDCLUSTERS[@]}; do
         oc get manifestwork -n ${managedcluster} >> ${BASE_COLLECTION_PATH}/Ramen_resources/get_manifestwork_${managedcluster}
         oc describe manifestwork -n ${managedcluster} >> ${BASE_COLLECTION_PATH}/Ramen_resources/desc_manifestwork_${managedcluster}
         oc get managedclusterview -n ${managedcluster} >> ${BASE_COLLECTION_PATH}/Ramen_resources/get_managedclusterview_${managedcluster}


### PR DESCRIPTION
This commit resolves the syntax issue due to
which the managedcluster details were not collected

Signed-off-by: yati1998 <ypadia@redhat.com>

