### PR TITLE
MGMT-9387: Inspect assisted-installer CRs in all namespaces

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -195,6 +195,12 @@ case "$CLUSTER" in
 
     oc adm inspect ansiblejobs.tower.ansible.com --all-namespaces  --dest-dir=must-gather
     
+    # Inspect Assisted-installer CRs
+    oc adm inspect infraenv.agent-install.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect clusterImageSet.hive.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect agentclusterinstall.extensions.hive.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect baremetalhost.metal3.io --all-namespaces --dest-dir=must-gather
+
     # gather hub imported as managed
     gather_spoke
     ;;


### PR DESCRIPTION
From the hub cluster, we need to dump some information about the assisted-installer resources. To do so, we inspect them in the HUB cluster.

Note: The 'clusterdeployments.hive.openshift.io' is already inspected in previous lines in the script.

**Related Issue:**  [MGMT-9387](https://issues.redhat.com/browse/MGMT-9387)

**Description of Changes:**

**What resource is being added**:
```
infraenv.agent-install.openshift.io
clusterImageSet.hive.openshift.io
agentclusterinstall.extensions.hive.openshift.io
baremetalhost.metal3.io
```

**Is this a Hub or Managed cluster change?:** 
Hub Cluster

**Notes:**
In the future, we might want to include some logs from the running pods of the `assisted-service` application.

cc: @mresvanis
