### PR TITLE
Add submariner data to gather

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -115,6 +115,9 @@ gather_spoke () {
     oc adm inspect ns/openshift-gatekeeper-system --dest-dir=must-gather
     oc adm inspect ns/openshift-operators --dest-dir=must-gather # gatekeeper and volsync operator will be installed in this ns in production
     oc adm inspect ns/openshift-gatekeeper-operator --dest-dir=must-gather
+
+    # Submariner logs
+    oc adm inspect ns/submariner-operator --dest-dir=must-gather
 }
 
 check_if_hub
@@ -204,6 +207,10 @@ case "$CLUSTER" in
     oc adm inspect clusterImageSet.hive.openshift.io --all-namespaces --dest-dir=must-gather
     oc adm inspect agentclusterinstall.extensions.hive.openshift.io --all-namespaces --dest-dir=must-gather
     oc adm inspect baremetalhost.metal3.io --all-namespaces --dest-dir=must-gather
+
+    # Submariner Addon CRs
+    oc adm inspect submarinerconfigs.submarineraddon.open-cluster-management.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect brokers.submariner.io --all-namespaces --dest-dir=must-gather
 
     # gather hub imported as managed
     gather_spoke


### PR DESCRIPTION
Add submariner-addon CRs and logs to gather.

Fixes https://github.com/stolostron/backlog/issues/22897

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

**Related Issue:**  stolostron/backlog#22897

**Description of Changes:**
 * Gather submariner-addon CRs
 * Gather pod log from submariner-operator namespace

**What resource is being added**: submarinerconfigs.submarineraddon.open-cluster-management.io, brokers.submariner.io

**Is this a Hub or Managed cluster change?:**
Hub Cluster, Managed Cluster

**Notes:**
Users will still need to run `subctl gather` to capture connectivity data, so this PR is only focussing on addon data which is not covered by subctl currently.