### PR TITLE
[release-2.4] MGMT-9387: Inspect assisted-installer CRs in all namespaces

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -138,6 +138,13 @@ case "$CLUSTER" in
 
     oc adm inspect ns/openshift-monitoring  --dest-dir=must-gather
     oc adm inspect ns/open-cluster-management-issuer  --dest-dir=must-gather
+
+    # Inspect Assisted-installer CRs
+    oc adm inspect infraenv.agent-install.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect clusterImageSet.hive.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect agentclusterinstall.extensions.hive.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect baremetalhost.metal3.io --all-namespaces --dest-dir=must-gather
+
     
     # gather hub imported as managed
     gather_spoke


### PR DESCRIPTION
This commit is a backport of https://github.com/stolostron/must-gather/pull/97 (80401327d39d4c1ca86e08485b470c07b90a7e42)

**Related Issue:**  open-cluster-management/backlog#<ISSUE_NUMBER>
JIRA MGMT-9387

**Description of Changes:**

See original PR being backported

**What resource is being added**: 

See original PR being backported

**Is this a Hub or Managed cluster change?:** 
Hub Cluster | Managed Cluster

See original PR being backported

**Notes:**

See original PR being backported