### PR TITLE
add cluster version and csv object outside gather-acm.log

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -127,6 +127,9 @@ gather_spoke () {
 
     # Submariner logs
     oc adm inspect ns/submariner-operator --dest-dir=must-gather
+
+    # Version info
+    oc adm --dest-dir=must-gather inspect clusterversions
 }
 
 check_if_hub
@@ -223,6 +226,10 @@ case "$CLUSTER" in
     # Submariner Addon CRs
     oc adm inspect submarinerconfigs.submarineraddon.open-cluster-management.io --all-namespaces --dest-dir=must-gather
     oc adm inspect brokers.submariner.io --all-namespaces --dest-dir=must-gather
+
+    # version information
+    oc adm --dest-dir=must-gather inspect clusterversions
+    oc adm --dest-dir=must-gather inspect csv -n "$HUBNAMESPACE"
 
     # gather hub imported as managed
     gather_spoke


### PR DESCRIPTION
**Related Issue:**  stolostron/backlog#<ISSUE_NUMBER>
No issue number

**Description of Changes:**
Adding objects of cluster version and csv object


**Is this a Hub or Managed cluster change?:**
Hub Cluster | Managed Cluster | N/A
Hub cluster

**Notes:**
The version may need to be also ported to the mce must gather image.   This is being done for ease of use of our must gather in anticipation of runs of automated insights rules against the must gather.  There are already parser written for the version, but not how we have it inputted in our log.  I'd like to have this end up in 2.5 and up if possible