### PR TITLE
Improve collection of Assisted Installer related resources

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -91,6 +91,8 @@ check_if_hub () {
 }
 
 gather_spoke () {
+    # collect CRDs to aid automated must-gather readers
+    oc adm inspect customresourcedefinition.apiextensions.k8s.io --dest-dir=must-gather
 
     # application resources on managed cluster
     oc adm inspect subscriptions.apps.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
@@ -217,10 +219,13 @@ case "$CLUSTER" in
     oc adm inspect ansiblejobs.tower.ansible.com --all-namespaces  --dest-dir=must-gather
 
     # Inspect Assisted-installer CRs
-    oc adm inspect infraenv.agent-install.openshift.io --all-namespaces --dest-dir=must-gather
-    oc adm inspect clusterImageSet.hive.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect agent.agent-install.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect agentclassification.agent-install.openshift.io --all-namespaces --dest-dir=must-gather
     oc adm inspect agentclusterinstall.extensions.hive.openshift.io --all-namespaces --dest-dir=must-gather
-    oc adm inspect baremetalhost.metal3.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect agentserviceconfig.agent-install.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect hypershiftagentserviceconfig.agent-install.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect infraenv.agent-install.openshift.io --all-namespaces --dest-dir=must-gather
+    oc adm inspect nmstateconfig.agent-install.openshift.io --all-namespaces --dest-dir=must-gather
 
     # Submariner Addon CRs
     oc adm inspect submarinerconfigs.submarineraddon.open-cluster-management.io --all-namespaces --dest-dir=must-gather


### PR DESCRIPTION
**Related Issue:**  stolostron/backlog#<ISSUE_NUMBER>

None

**Description of Changes:**

Stop collecting `baremetalhost.metal3.io` and `clusterImageSet.hive.openshift.io` under the `# Inspect Assisted-installer CRs` comment because they're already collected in a difference place in the script

Start collecting missing:
    * `agent.agent-install.openshift.io`
    * `agentclassification.agent-install.openshift.io`
    * `agentserviceconfig.agent-install.openshift.io`
    * `hypershiftagentserviceconfig.agent-install.openshift.io`
    * `nmstateconfig.agent-install.openshift.io`

Also added collection of CRDs to aid automated must-gather reading tools (and it's nice to have in gathers in general)

**What resource is being added**: 

See description

**Is this a Hub or Managed cluster change?:**

Hub

**Notes:**

None