### PR TITLE
ACM-3267 add search-v2-operator to must-gather

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -231,6 +231,8 @@ gather_hub(){
     oc adm inspect  discoveryconfigs.discovery.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect searchoperators.search.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect searchcustomizations.search.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+    oc adm inspect searches.search.open-cluster-management.io --all-namespaces --dest-dir=must-gather
+
 
     oc adm inspect ns/openshift-monitoring  --dest-dir=must-gather
     oc adm inspect ns/open-cluster-management-issuer  --dest-dir=must-gather

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -229,8 +229,6 @@ gather_hub(){
     oc adm inspect  discoveredclusterrefreshes.discovery.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect  discoveredclusters.discovery.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect  discoveryconfigs.discovery.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
-    oc adm inspect searchoperators.search.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
-    oc adm inspect searchcustomizations.search.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect searches.search.open-cluster-management.io --all-namespaces --dest-dir=must-gather
 
 


### PR DESCRIPTION
Signed-off-by: Anxhela <acoba@redhat.com>

**Related Issue:**  [JIRA ISSUE](https://issues.redhat.com/browse/ACM-3267)

**Description of Changes:**

**What resource is being added**: search-v2-operator

**Is this a Hub or Managed cluster change?:**
Hub Cluster | Managed Cluster | N/A

**Notes:**
