### PR TITLE
Add appsetreport for argo pull model

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -207,6 +207,7 @@ gather_hub(){
     for a in $ARGONS;
         oc adm inspect ns/"$a"  --dest-dir=must-gather
     done
+    oc adm inspect multiclusterapplicationsetreports.apps.open-cluster-management.io --dest-dir=must-gather
 
     oc adm inspect policies.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect policysets.policy.open-cluster-management.io --all-namespaces  --dest-dir=must-gather


### PR DESCRIPTION
**Related Issue:**  stolostron/backlog#: ACM-1301

**Description of Changes:**
In ACM 2.8, for the new argoCD pull model feature, we introduced a new CRD: multiclusterapplicationsetreports.apps.open-cluster-management.io. We need to gather these resources from the hub.

**What resource is being added**: multiclusterapplicationsetreports.apps.open-cluster-management.io

**Is this a Hub or Managed cluster change?:**
Hub Cluster

**Notes:**
