### PR TITLE
Collect metal3 pods data if ACM hub uses BMC to create/scale clusters using ACM

### DIFF
--- a/collection-scripts/mce-gather.sh
+++ b/collection-scripts/mce-gather.sh
@@ -149,7 +149,7 @@ gather_hub() {
     # OpenShift console plug-in enablement
     oc adm inspect consoles.operator.openshift.io --dest-dir=must-gather
     
-    # Capture metal3 logs if the customer is using BMC 
+    # Capture metal3 logs if the customer has at least one baremetalhost cr which indicates that bmc is being used to create new clusters 
     if oc get baremetalhosts.metal3.io --all-namespaces &> /dev/null; 
     then
       oc adm inspect ns/openshift-machine-api --dest-dir=must-gather

--- a/collection-scripts/mce-gather.sh
+++ b/collection-scripts/mce-gather.sh
@@ -148,6 +148,13 @@ gather_hub() {
 
     # OpenShift console plug-in enablement
     oc adm inspect consoles.operator.openshift.io --dest-dir=must-gather
+    
+    # Capture metal3 logs if the customer is using BMC 
+    if oc get baremetalhosts.metal3.io --all-namespaces &> /dev/null; 
+    then
+      oc adm inspect ns/openshift-machine-api --dest-dir=must-gather
+    fi
+    
 }
 
 check_if_hub


### PR DESCRIPTION
Metal3 pods logs is required to investigate issues related to Cluster installations that are being made using BMC

**Related Issue:**  stolostron/backlog#<ISSUE_NUMBER> NA

**Description of Changes:**
The metal3 pods logs are captured if there's at least one BaremetalHost CR. The BaremetalHosts CR are usually created when you opt to create/scale clusters using BMC

**What resource is being added**: <resource name> | N/A
We are running an inspect against the openshift-machine-api that has the metal3 operator pods

**Is this a Hub or Managed cluster change?:**
This needs to be captured from the ACM hub 


**Notes:**
