### PR TITLE
collect addondeploymentconfigs via must-gather

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -238,6 +238,7 @@ gather_hub(){
     oc adm inspect observabilityaddons.observability.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect multiclusterobservabilities.observability.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect managedclusteraddons.addon.open-cluster-management.io  --all-namespaces  --dest-dir=must-gather
+    oc adm inspect addondeploymentconfigs.addon.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect ns/open-cluster-management-observability --dest-dir=must-gather
     oc adm inspect observatoria.core.observatorium.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect ns/open-cluster-management-addon-observability --dest-dir=must-gather


### PR DESCRIPTION
**Related Issue:**  stolostron/backlog#

**Description of Changes:**
Customer creates addondeploymentconfigs. RHACM components also create these objects. They must be collected as part of `must-gather`

**What resource is being added**: addondeploymentconfigs.addon.open-cluster-management.io

**Is this a Hub or Managed cluster change?:**
Hub Cluster

**Notes:**
