### PR TITLE
Add preprovisioning images to must-gather scripts

### DIFF
--- a/collection-scripts/mce-gather.sh
+++ b/collection-scripts/mce-gather.sh
@@ -132,6 +132,7 @@ gather_hub() {
     oc adm inspect operatorgroups.operators.coreos.com --all-namespaces --dest-dir=$BASE_COLLECTION_PATH
 
     oc adm inspect baremetalhosts.metal3.io --all-namespaces --dest-dir=$BASE_COLLECTION_PATH
+    oc adm inspect preprovisioningimages.metal3.io --all-namespaces --dest-dir=$BASE_COLLECTION_PATH
 
     oc adm inspect placementdecisions.cluster.open-cluster-management.io --all-namespaces --dest-dir=$BASE_COLLECTION_PATH
     oc adm inspect placements.cluster.open-cluster-management.io --all-namespaces --dest-dir=$BASE_COLLECTION_PATH


### PR DESCRIPTION


**Related Issue:**  N/A

**Description of Changes:**

These are used for defining the image ironic should deploy to a host

**What resource is being added**: preprovisioningimages

**Is this a Hub or Managed cluster change?:**
Hub Cluster

**Notes:**
