### PR TITLE
add to collect cluster permission resources

### DIFF
--- a/collection-scripts/gather_application_lifecycle_logs
+++ b/collection-scripts/gather_application_lifecycle_logs
@@ -28,4 +28,5 @@ for a in $ARGONS;
 do
     oc adm inspect ns/"$a"  --dest-dir=must-gather
 done
-oc adm inspect multiclusterapplicationsetreports.apps.open-cluster-management.io --dest-dir=must-gather
+oc adm inspect multiclusterapplicationsetreports.apps.open-cluster-management.io --all-namespaces --dest-dir=must-gather
+oc adm inspect clusterpermission.rbac.open-cluster-management.io --all-namespaces --dest-dir=must-gather


### PR DESCRIPTION
**Related Issue:**  stolostron/backlog#<ISSUE_NUMBER>

https://issues.redhat.com/browse/ACM-4413

**Description of Changes:**
1. append to collect the new cluster-permission API resource in ACM 2.9 release.
2. fix the collection of the multiclusterapplicationsetreports resource, It is namespaced resource


**What resource is being added**: <resource name> | N/A
clusterpermission.rbac.open-cluster-management.io

**Is this a Hub or Managed cluster change?:**
Hub Cluster | Managed Cluster | N/A

Hub Cluster

**Notes:**
