### PR TITLE
MGMT-15578: Gather service and event logs for failed MCE agents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ FROM quay.io/openshift/origin-cli:4.13 as builder
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN microdnf update -y \
-    && microdnf install -y tar rsync findutils gzip iproute util-linux \
+    && microdnf install -y tar rsync findutils gzip iproute util-linux wget \
     && microdnf clean all
+
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64 -O /usr/bin/yq &&\
+    chmod +x /usr/bin/yq
 
 # Copy oc binary
 COPY --from=builder /usr/bin/oc /usr/bin/oc

--- a/collection-scripts/gather_mce_logs
+++ b/collection-scripts/gather_mce_logs
@@ -167,6 +167,30 @@ then
         return
     fi
   }
+
+  gather_service_and_event_logs_for_failed_agents() {
+    GATHER_DIR="$1"
+    find ${GATHER_DIR} -path '*/agentclusterinstalls/*.yaml' -type f | while read file; do
+        dir=$(dirname $file)
+        base=$(basename -s .yaml $file)
+
+        # yq eval '.status.conditions[] | select(.type == "Failed") | .status'  must-gather/namespaces/local-cluster/extensions.hive.openshift.io/agentclusterinstalls/local-cluster-cluster-install.yaml
+        failed=$(yq eval '.status.conditions[] | select(.type == "Failed") | .status' $file)
+        if [ "$failed" = "False" ]; then
+                echo "skipping logs and events for non-failed cluster $file"
+                continue
+        fi
+
+        logsURL=$(yq eval '.status.debugInfo.logsURL' $file)
+        if [ -n ${logsURL} ]; then
+                curl -k -o $dir/$base.logs.tar "${logsURL}"
+        fi
+        eventsURL=$(yq eval '.status.debugInfo.eventsURL' $file)
+        if [ -n ${eventsURL} ]; then
+                curl -k -o $dir/$base.events "${eventsURL}"
+        fi
+    done
+  }
   
   gather_hub() {
       check_managed_clusters
@@ -264,8 +288,11 @@ then
   
       # OpenShift console plug-in enablement
       oc adm inspect consoles.operator.openshift.io --dest-dir=must-gather
+
+      # Gather any service or event logs for failed agents
+      gather_service_and_event_logs_for_failed_agents must-gather
   }
-  
+
   echo "Start to gather MCE information for hub"
   gather_hub
   check_if_hypershift "$@"


### PR DESCRIPTION
This change introduces the capability to remove service and event logs for failed MCE agents.

**Related Issue:**  https://issues.redhat.com/browse/MGMT-15578

**Description of Changes:**
We are adding an ability to the MCE gather to obtain logs and events from agentclusterinstall CR's that are marked as "failed" where these logs are available.

**What resource is being added**: <resource name> | N/A

**Is this a Hub or Managed cluster change?:**
Hub Cluster | Managed Cluster | N/A

**Notes:**
