### PR TITLE
Update origin-cli builder to 4.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-FROM quay.io/openshift/origin-cli:4.13 as builder
+FROM quay.io/openshift/origin-cli:4.15 as builder
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 


### PR DESCRIPTION
**Related Issue:**  https://issues.redhat.com/browse/ACM-7713

**Description of Changes:** Update image base to use newest `oc` version

**What resource is being added**: N/A

**Is this a Hub or Managed cluster change?:**
 N/A

**Notes:**

A fix was made in `oc` so that ConfigurationPolicies can be correctly gathered by the `oc adm inspect` commands this uses. Without the fix, almost no information about most ConfigurationPolicies will be recorded.