### PR TITLE
update globalhub namespace

### DIFF
--- a/collection-scripts/gather_hub_logs
+++ b/collection-scripts/gather_hub_logs
@@ -17,8 +17,8 @@ then
   oc adm inspect  ns/open-cluster-management-backup  --dest-dir=must-gather
   # request from https://bugzilla.redhat.com/show_bug.cgi?id=1853485
   oc get proxy -o yaml > ${BASE_COLLECTION_PATH}/gather-proxy.log
-  oc adm inspect  multiclusterhubs.operator.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
-  oc adm inspect  klusterletaddonconfigs.agent.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+  oc adm inspect multiclusterhubs.operator.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
+  oc adm inspect klusterletaddonconfigs.agent.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
   oc adm inspect validatingwebhookconfigurations.admissionregistration.k8s.io --all-namespaces --dest-dir=must-gather
   oc adm inspect mutatingwebhookconfigurations.admissionregistration.k8s.io --all-namespaces --dest-dir=must-gather
   oc adm inspect managedclusteraddons.addon.open-cluster-management.io  --all-namespaces  --dest-dir=must-gather
@@ -57,6 +57,9 @@ then
     do
         oc adm inspect ns/"$pns"  --dest-dir=must-gather
     done
+    GLOBALHUB_NAMESPACE=$(oc get multiclusterglobalhubs.operator.open-cluster-management.io --all-namespaces --no-headers=true| awk '{ print $1 }')
+    echo "GlobalHub namespace: $GLOBALHUB_NAMESPACE"
+    oc adm inspect ns/"$GLOBALHUB_NAMESPACE" --dest-dir=must-gather
   fi
 
   # Get disconneted information

--- a/collection-scripts/gather_spoke_logs
+++ b/collection-scripts/gather_spoke_logs
@@ -70,7 +70,7 @@ then
     oc adm inspect ns/submariner-operator --dest-dir=must-gather
 
     # Multicluster Global Hub Agent information
-    oc adm inspect ns/open-cluster-management-global-hub-system --dest-dir=must-gather
+    oc adm inspect ns/multicluster-global-hub-agent --dest-dir=must-gather
 
     # Get disconneted information
     oc adm inspect imagecontentsourcepolicies.operator.openshift.io  --all-namespaces --dest-dir=must-gather


### PR DESCRIPTION
**Related Issue:**  stolostron/backlog#<ISSUE_NUMBER>
https://issues.redhat.com/browse/ACM-9153

**Description of Changes:**
the globalhub namespace in incorrect

**What resource is being added**: <resource name> | N/A

**Is this a Hub or Managed cluster change?:**
Hub Cluster | Managed Cluster | N/A

**Notes:**
