### PR TITLE
update globalhub namespace

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -159,7 +159,7 @@ gather_spoke () {
     oc adm inspect ns/submariner-operator --dest-dir=must-gather
 
     # Multicluster Global Hub Agent information
-    oc adm inspect ns/open-cluster-management-global-hub-system --dest-dir=must-gather
+    oc adm inspect ns/multicluster-global-hub-agent --dest-dir=must-gather
 
     # Get disconneted information
     oc adm inspect imagecontentsourcepolicies.operator.openshift.io  --all-namespaces --dest-dir=must-gather
@@ -293,6 +293,9 @@ gather_hub(){
       do
           oc adm inspect ns/"$pns"  --dest-dir=must-gather
       done
+      GLOBALHUB_NAMESPACE=$(oc get multiclusterglobalhubs.operator.open-cluster-management.io --all-namespaces --no-headers=true | awk '{ print $1 }')
+      echo "GlobalHub namespace: $GLOBALHUB_NAMESPACE"
+      oc adm inspect ns/"$GLOBALHUB_NAMESPACE" --dest-dir=must-gather
     fi
 
     # Get disconneted information


### PR DESCRIPTION
**Related Issue:**  stolostron/backlog#<ISSUE_NUMBER>
https://issues.redhat.com/browse/ACM-9153

**Description of Changes:**
The globalhub namespace in incorrect

**What resource is being added**: <resource name> | N/A

**Is this a Hub or Managed cluster change?:**
Hub Cluster | Managed Cluster | N/A

**Notes:**
