### PR TITLE
Running gather scripts in background

### DIFF
--- a/collection-scripts/gather_all_logs
+++ b/collection-scripts/gather_all_logs
@@ -3,9 +3,29 @@
 # Copyright (c) 2023 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-source /usr/bin/gather_mce_logs
-source /usr/bin/gather_hub_logs
-source /usr/bin/gather_observability_logs
-source /usr/bin/gather_application_lifecycle_logs
-source /usr/bin/gather_dr_logs
-source /usr/bin/gather_governance_logs
+# Store PIDs of all the subprocesses
+pids=()
+
+source /usr/bin/gather_mce_logs &
+pids+=($!)
+
+source /usr/bin/gather_hub_logs &
+pids+=($!)
+
+source /usr/bin/gather_observability_logs &
+pids+=($!)
+
+source /usr/bin/gather_application_lifecycle_logs &
+pids+=($!)
+
+source /usr/bin/gather_dr_logs &
+pids+=($!)
+
+source /usr/bin/gather_governance_logs &
+pids+=($!)
+
+# Check if PID array has any values, if so, wait for them to finish
+if [ ${#pids[@]} -ne 0 ]; then
+    echo "Waiting on subprocesses to finish execution."
+    wait "${pids[@]}"
+fi


### PR DESCRIPTION
**Related Issue:**  stolostron/backlog#<ISSUE_NUMBER>

**Description of Changes:**
To save time when running the ACM MG, the collection scripts can be executed in parallel.

Process:
1. Running gather scripts in parallel 
2. Waiting on subprocesses to finish execution.

**What resource is being added**: <resource name> | N/A

**Is this a Hub or Managed cluster change?:**
Hub Cluster | Managed Cluster | N/A

**Notes:**
