### PR TITLE
gather globalhub agent pod log

### DIFF
--- a/collection-scripts/gather_hub_logs
+++ b/collection-scripts/gather_hub_logs
@@ -64,6 +64,9 @@ then
     oc adm inspect ns/"$GLOBALHUB_NAMESPACE" --dest-dir=must-gather
   fi
 
+  # Multicluster Global Hub Agent information
+  oc adm inspect ns/multicluster-global-hub-agent --dest-dir=must-gather
+
   # Get disconneted information
   oc adm inspect imagecontentsourcepolicies.operator.openshift.io  --all-namespaces --dest-dir=must-gather
 

--- a/collection-scripts/gather_spoke_logs
+++ b/collection-scripts/gather_spoke_logs
@@ -69,9 +69,6 @@ then
     # Submariner logs
     oc adm inspect ns/submariner-operator --dest-dir=must-gather
 
-    # Multicluster Global Hub Agent information
-    oc adm inspect ns/multicluster-global-hub-agent --dest-dir=must-gather
-
     # Get disconneted information
     oc adm inspect imagecontentsourcepolicies.operator.openshift.io  --all-namespaces --dest-dir=must-gather
 


### PR DESCRIPTION
**Related Issue:**  stolostron/backlog
https://issues.redhat.com/browse/ACM-10405

**Description of Changes:**
As globalhub agent running on the ACM hub cluster, so we should add the logic to hub cluster instead of managed cluster.

**What resource is being added**: <resource name> | N/A

multicluster-global-hub-agent pod log

**Is this a Hub or Managed cluster change?:**
Hub Cluster 


**Notes:**
