### PR TITLE
Revert `Makefile.prow` removal

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -1,0 +1,4 @@
+@@ -1,7 +0,0 @@
+# Copyright Contributors to the Open Cluster Management project
+
+-include /opt/build-harness/Makefile.prow


### PR DESCRIPTION
Partially revert d5acc478aaeb12213774fe68ffbc51645d4fd34b

`Makefile.prow` is used in Prow CI.
