### PR TITLE
Remove `baseBranches`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "schedule": ["at any time"],
-  "timezone": "America/New_York",
-  "useBaseBranchConfig": "merge"
+  "dockerfile": {
+    "fileMatch": ["build/Dockerfile.rhtap"]
+  },
+  "schedule": ["every weekend"],
+  "timezone": "America/New_York"
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["/(^main$)|(^release-2\\.(10|11)$)/"],
   "schedule": ["at any time"],
   "timezone": "America/New_York",
   "useBaseBranchConfig": "merge"


### PR DESCRIPTION
Now that I know I can scriptify editing the target branch, it's trivial to just move the target branch to `main` each time there's an update. (Also, I went ahead an took advantage of the fact that I can update the `Component` object 😄 )