### PR TITLE
fix(KONFLUX-3663): format PipelineRun files and upload SAST results

### DIFF
--- a/.tekton/must-gather-acm-210-pull-request.yaml
+++ b/.tekton/must-gather-acm-210-pull-request.yaml
@@ -301,7 +301,7 @@ spec:
               - "false"
       - name: sast-snyk-check
         runAfter:
-          - clone-repository
+          - build-container
         taskRef:
           params:
             - name: name
@@ -319,6 +319,11 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
+        params:
+          - name: image-digest
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-container.results.IMAGE_URL)
       - name: clamav-scan
         params:
           - name: image-digest

--- a/.tekton/must-gather-acm-210-push.yaml
+++ b/.tekton/must-gather-acm-210-push.yaml
@@ -298,7 +298,7 @@ spec:
               - "false"
       - name: sast-snyk-check
         runAfter:
-          - clone-repository
+          - build-container
         taskRef:
           params:
             - name: name
@@ -316,6 +316,11 @@ spec:
         workspaces:
           - name: workspace
             workspace: workspace
+        params:
+          - name: image-digest
+            value: $(tasks.build-container.results.IMAGE_DIGEST)
+          - name: image-url
+            value: $(tasks.build-container.results.IMAGE_URL)
       - name: clamav-scan
         params:
           - name: image-digest


### PR DESCRIPTION
This update configures the SAST task to upload SARIF results to quay.io for
long-term storage

Related: 
- https://issues.redhat.com/browse/KONFLUX-3663
- https://issues.redhat.com/browse/KONFLUX-2263