### PR TITLE
ACM-13458: Add imageclusterinstall to MCE gather

### DIFF
--- a/collection-scripts/gather_mce_logs
+++ b/collection-scripts/gather_mce_logs
@@ -274,6 +274,9 @@ if [ -z $GATHER_MCE_RAN ] || [ $GATHER_MCE_RAN != true ]; then
     run_inspect infraenv.agent-install.openshift.io --all-namespaces
     run_inspect nmstateconfig.agent-install.openshift.io --all-namespaces
 
+    # Image Based Install Operator CRs
+    run_inspect imageclusterinstall.extensions.hive.openshift.io --all-namespaces
+
     # OpenShift console plug-in enablement
     run_inspect consoles.operator.openshift.io
 


### PR DESCRIPTION
**Related Issue:** https://issues.redhat.com/browse/ACM-13458

**Description of Changes:** Adds imageclusterinstall to MCE must-gather

**What resource(s) are being added:** `imageclusterinstall.extensions.hive.openshift.io`

**Is this a Hub or Managed cluster change?:**

- [x] Hub Cluster
- [ ] Managed Cluster
- [ ] N/A

**Notes:** Required for image-based-install-operator GA
