### PR TITLE
[ACM-13625] Added internal Installer CRDs to must-gather

### DIFF
--- a/collection-scripts/gather_hub_logs
+++ b/collection-scripts/gather_hub_logs
@@ -24,6 +24,7 @@ if [ -z $GATHER_HUB_RAN ] || [ $GATHER_HUB_RAN != true ]; then
   # request from https://bugzilla.redhat.com/show_bug.cgi?id=1853485
   oc get proxy -o yaml >${BASE_COLLECTION_PATH}/gather-proxy.log
   run_inspect multiclusterhubs.operator.open-cluster-management.io --all-namespaces
+  run_inspect internalhubcomponents.operator.open-cluster-management.io --all-namespaces
   run_inspect klusterletaddonconfigs.agent.open-cluster-management.io --all-namespaces
   run_inspect validatingwebhookconfigurations.admissionregistration.k8s.io --all-namespaces
   run_inspect mutatingwebhookconfigurations.admissionregistration.k8s.io --all-namespaces

--- a/collection-scripts/gather_mce_logs
+++ b/collection-scripts/gather_mce_logs
@@ -219,6 +219,7 @@ if [ -z $GATHER_MCE_RAN ] || [ $GATHER_MCE_RAN != true ]; then
     oc get proxy -o yaml >${BASE_COLLECTION_PATH}/gather-proxy-mce.log
     run_inspect ns/hive
     run_inspect multiclusterengines.multicluster.openshift.io --all-namespaces
+    run_inspect internalenginecomponents.multicluster.openshift.io --all-namespaces
     run_inspect hiveconfigs.hive.openshift.io --all-namespaces
 
     run_inspect clusterserviceversions.operators.coreos.com --all-namespaces


### PR DESCRIPTION
**Related Issue:**
https://issues.redhat.com/browse/ACM-13625

**Description of Changes:**
Added `InternalHubComponent` and `InternalEngineComponent` to list of resources for must-gather to extract.

**What resource(s) are being added:**
`InternalHubComponent` and `InternalEngineComponent`.

**Is this a Hub or Managed cluster change?:**

- [x] Hub Cluster
- [ ] Managed Cluster
- [ ] N/A

**Notes:**
