### PR TITLE
collect new globalhub ns data

### DIFF
--- a/collection-scripts/gather_hub_logs
+++ b/collection-scripts/gather_hub_logs
@@ -73,6 +73,7 @@ if [ -z $GATHER_HUB_RAN ] || [ $GATHER_HUB_RAN != true ]; then
 
   # Multicluster Global Hub Agent information
   run_inspect ns/multicluster-global-hub-agent
+  run_inspect ns/open-cluster-management-global-hub-agent-addon
 
   # Get disconneted information
   run_inspect imagecontentsourcepolicies.operator.openshift.io --all-namespaces


### PR DESCRIPTION
**Related Issue:**
story: https://issues.redhat.com/browse/ACM-12718
doc pr: https://github.com/stolostron/rhacm-docs/pull/6971/files#diff-426c3333e3d6698409184255e75546191f82b8b362dc8f713fb9e77a00c289e1R24
**Description of Changes:**
Globalhub will install some addons in `open-cluster-management-global-hub-agent-addon` ns, so we need to collect the log in this ns.

**What resource(s) are being added:**
resoueces in ns `open-cluster-management-global-hub-agent-addon`

**Is this a Hub or Managed cluster change?:**

- [x] Hub Cluster
- [ ] Managed Cluster
- [ ] N/A

**Notes:**
