### PR TITLE
Gather CRD when not using self management

### DIFF
--- a/collection-scripts/gather_mce_logs
+++ b/collection-scripts/gather_mce_logs
@@ -179,6 +179,7 @@ if [ -z $GATHER_MCE_RAN ] || [ $GATHER_MCE_RAN != true ]; then
 
   gather_hub() {
     check_managed_clusters
+    run_inspect customresourcedefinition.apiextensions.k8s.io
 
     if [[ -z "$MCE_NAME" ]]; then
       MCE_NAME=$(oc get multiclusterengines.multicluster.openshift.io --all-namespaces --no-headers=true | awk '{ print $1 }')


### PR DESCRIPTION
**Related Issue:**
CRD isn't collected when hub isn't self managed

**Description of Changes:**
Add CRD collection to must gather when Hub is not self managed

**What resource(s) are being added:**
CRD

**Is this a Hub or Managed cluster change?:**

- [X] Hub Cluster
- [ ] Managed Cluster
- [ ] N/A

**Notes:**
