### PR TITLE
Fix relative path for Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 .PHONY: clean
 clean:
 	-rm -rf must-gather/
+	-rm kubeconfig
 
 ############################################################
 # run section
@@ -14,10 +15,12 @@ clean:
 run: clean
 	./collection-scripts/gather
 
-.PHONY: run-image
-run-image:
-	-mkdir must-gather/
+kubeconfig:
 	oc config view --minify --raw > kubeconfig
+
+.PHONY: run-image
+run-image: kubeconfig
+	-mkdir must-gather/
 	${CONTAINER_ENGINE} run -v $(PWD)/kubeconfig:/kube/config --env KUBECONFIG=/kube/config \
 		-v $(PWD)/must-gather:/must-gather $(IMAGE_NAME_AND_VERSION):$(TAG)
 
@@ -36,4 +39,4 @@ IMAGE_NAME_AND_VERSION ?= $(REGISTRY)/$(IMG)
 
 .PHONY: build-image
 build-image:
-	$(CONTAINER_ENGINE) build --platform linux/amd64 -t $(IMAGE_NAME_AND_VERSION):$(TAG) -f build/Dockerfile
+	$(CONTAINER_ENGINE) build --platform linux/amd64 -t $(IMAGE_NAME_AND_VERSION):$(TAG) -f build/Dockerfile .

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -21,10 +21,10 @@ COPY --from=builder /usr/bin/oc /usr/bin/oc
 COPY --from=builder /usr/bin/yq /usr/bin/yq
 
 # copy all collection scripts to /usr/bin
-COPY collection-scripts/* /usr/bin/
+COPY ./collection-scripts/* /usr/bin/
 
 # Setup non-root user
-COPY build/user_setup /usr/local/bin/
+COPY ./build/user_setup /usr/local/bin/
 RUN  /usr/local/bin/user_setup
 USER 1001
 


### PR DESCRIPTION
The Dockerfile was moved, so it was no longer finding the script files.

Also, move the `kubeconfig` generation so it's not regenerated on every run.