### PR TITLE
Fix hypershift must-gather

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Must Gather Script for Open Cluster Management
 
 The must gather script for Open Cluster Management allows a user to collect information about
-various key resources and namespaces that exist on your cluster.
+various key resources and namespaces that exist on your cluster. Scripts are shell scripts located
+in the [`collection-scripts/`](./collection-scripts/) directory. The default/root script is the
+[`gather`](./collection-scripts/gather) script.
 
 ## Usage
 
@@ -105,6 +107,9 @@ running:
 ```sh
 make run
 ```
+
+**NOTE:** This invokes the [`collection-scripts/gather`](./collection-scripts/gather) script. Each
+of the sub-scripts can alternatively be invoked individually.
 
 You can also build and run the image locally:
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@ ENV BASE_COLLECTION_PATH=/must-gather \
     USER_NAME=must-gather
 
 RUN microdnf update -y \
-    && microdnf install -y rsync findutils \
+    && microdnf install -y tar gzip rsync findutils \
     && microdnf clean all
 
 # Copy binaries

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -13,7 +13,7 @@ ENV BASE_COLLECTION_PATH=/must-gather \
     USER_NAME=must-gather
 
 RUN microdnf update -y \
-    && microdnf install -y rsync findutils \
+    && microdnf install -y tar gzip rsync findutils \
     && microdnf clean all
 
 # Copy binaries

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -18,11 +18,11 @@ export GATHER_HUB_RAN=false
 
 check_if_engine() {
   MCE_NAME=$(oc get multiclusterengines.multicluster.openshift.io --all-namespaces --no-headers=true | awk '{ print $1 }')
-  if [[ -n "$MCE_NAME" ]]; then
-    log "Detected MCE resource: \"$MCE_NAME\" on current cluster. This cluster has been verified as an engine cluster."
+  if [[ -n "${MCE_NAME}" ]]; then
+    log "Detected MCE resource: \"${MCE_NAME}\" on current cluster. This cluster has been verified as an engine cluster."
     MCE_CLUSTER=true
     OPERATOR_NAMESPACE=$(oc get pod -l control-plane=backplane-operator --all-namespaces --no-headers=true | head -n 1 | awk '{ print $1 }')
-    DEPLOYMENT_NAMESPACE=$(oc get mce "$MCE_NAME" -o jsonpath='{.spec.targetNamespace}')
+    DEPLOYMENT_NAMESPACE=$(oc get mce "${MCE_NAME}" -o jsonpath='{.spec.targetNamespace}')
   else
     log "No MCE resource detected on the current cluster. This is not an engine cluster (Previous errors can be safely ignored)."
   fi
@@ -51,9 +51,9 @@ check_if_spoke() {
 check_if_engine
 check_if_spoke
 
-if $MCE_CLUSTER; then
+if ${MCE_CLUSTER}; then
   check_if_hub
-  if $HUB_CLUSTER; then
+  if ${HUB_CLUSTER}; then
     # NOTE: The `gather_all_logs` script includes `gather_mce_logs`
     log "Running ACM MultiClusterHub Must-Gather"
     ${SCRIPT_DIR}/gather_all_logs
@@ -63,7 +63,7 @@ if $MCE_CLUSTER; then
   fi
 fi
 
-if $SPOKE_CLUSTER; then
+if ${SPOKE_CLUSTER}; then
   ${SCRIPT_DIR}/gather_spoke_logs
 fi
 

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -15,6 +15,10 @@ export OPERATOR_NAMESPACE=""
 export DEPLOYMENT_NAMESPACE=""
 export GATHER_MCE_RAN=false
 export GATHER_HUB_RAN=false
+export HC_NAME=""
+export HC_NAMESPACE="clusters" # default hosted cluster namespace
+
+parse_args "$@"
 
 check_if_engine() {
   MCE_NAME=$(oc get multiclusterengines.multicluster.openshift.io --all-namespaces --no-headers=true | awk '{ print $1 }')

--- a/collection-scripts/gather_mce_logs
+++ b/collection-scripts/gather_mce_logs
@@ -21,7 +21,7 @@ if [ -z $GATHER_MCE_RAN ] || [ $GATHER_MCE_RAN != true ]; then
   fi
 
   # Set a file path for the gather managed clusters.
-  MANAGED_CLUSTER_FILE_PATH=$BASE_COLLECTION_PATH/gather-managed.log
+  MANAGED_CLUSTER_FILE_PATH=${BASE_COLLECTION_PATH}/gather-managed.log
 
   HC_NAME=""
   HC_NAMESPACE="clusters" # default hosted cluster namespace

--- a/collection-scripts/gather_mce_logs
+++ b/collection-scripts/gather_mce_logs
@@ -23,8 +23,8 @@ if [ -z $GATHER_MCE_RAN ] || [ $GATHER_MCE_RAN != true ]; then
   # Set a file path for the gather managed clusters.
   MANAGED_CLUSTER_FILE_PATH=${BASE_COLLECTION_PATH}/gather-managed.log
 
-  HC_NAME=""
-  HC_NAMESPACE="clusters" # default hosted cluster namespace
+  HC_NAME=${HC_NAME:-""}
+  HC_NAMESPACE=${HC_NAMESPACE:-"clusters"}
 
   check_managed_clusters() {
     touch $MANAGED_CLUSTER_FILE_PATH
@@ -40,27 +40,6 @@ if [ -z $GATHER_MCE_RAN ] || [ $GATHER_MCE_RAN != true ]; then
 
     for mcns in ${mc_namespaces}; do
       run_inspect ns/"$mcns"
-    done
-  }
-
-  check_if_hypershift() {
-    # get the hosted cluster name and optionally namespace
-    while [ "$1" != "" ]; do
-      FLAG=$(echo "$1" | awk -F= '{print $1}')
-      VALUE=$(echo "$1" | awk -F= '{print $2}')
-      case $FLAG in
-      hosted-cluster-name)
-        HC_NAME=$VALUE
-        ;;
-      hosted-cluster-namespace)
-        HC_NAMESPACE=$VALUE
-        ;;
-      *)
-        log "ERROR" "unknown parameter \"$FLAG\""
-        exit 1
-        ;;
-      esac
-      shift
     done
   }
 
@@ -289,7 +268,7 @@ if [ -z $GATHER_MCE_RAN ] || [ $GATHER_MCE_RAN != true ]; then
 
   log "Starting MCE Hub cluster must-gather"
   gather_hub
-  check_if_hypershift "$@"
+  parse_args "$@"
   dump_hostedcluster
 
   export GATHER_MCE_RAN=true

--- a/collection-scripts/gather_mce_logs
+++ b/collection-scripts/gather_mce_logs
@@ -50,8 +50,7 @@ if [ -z $GATHER_MCE_RAN ] || [ $GATHER_MCE_RAN != true ]; then
     fi
 
     # Get a running hypershift operator pod
-    oc project hypershift
-    HO_POD_NAME=$(oc get pod --no-headers=true --field-selector=status.phase=Running -l app=operator -o custom-columns="NAME:.metadata.name" | head -n 1)
+    HO_POD_NAME=$(oc get pod -n hypershift --no-headers=true --field-selector=status.phase=Running -l app=operator -o custom-columns="NAME:.metadata.name" | head -n 1)
 
     if [[ -n $HO_POD_NAME ]]; then
       log "Found a running hypershift operator pod: \"$HO_POD_NAME\""
@@ -61,8 +60,9 @@ if [ -z $GATHER_MCE_RAN ] || [ $GATHER_MCE_RAN != true ]; then
     fi
 
     # Extract the hypershift CLI from the hypershift operator pod
-    oc rsync ${HO_POD_NAME}:/usr/bin/hypershift /tmp
+    oc rsync -n hypershift -c operator --strategy tar ${HO_POD_NAME}:/usr/bin/hypershift /tmp
     chmod 755 /tmp/hypershift
+
     return 0
   }
 

--- a/collection-scripts/gather_utils
+++ b/collection-scripts/gather_utils
@@ -30,3 +30,27 @@ run_inspect() {
   # - BASE_COLLECTION_PATH can't be quoted because `oc` reads the quotes as part of the path
   oc adm inspect --dest-dir=${BASE_COLLECTION_PATH} "$@"
 }
+
+# parse_args parses the arguments passed to the must-gather in the form of <key>=<value>.
+# NOTE: Currently this only applies to the Hypershift must-gather.
+parse_args() {
+  # get the hosted cluster name and optionally namespace
+  while [ "${1}" != "" ]; do
+    local key value
+    key=${1%=*}
+    value=${1#*=}
+    case ${key} in
+    hosted-cluster-name) # Get the hosted cluster name
+      export HC_NAME=${value}
+      ;;
+    hosted-cluster-namespace) # Get the hosted cluster namespace
+      export HC_NAMESPACE=${value}
+      ;;
+    *)
+      log "ERROR" "unknown parameter \"${key}\""
+      exit 1
+      ;;
+    esac
+    shift
+  done
+}


### PR DESCRIPTION
Previously the `gather_mce_logs` script was sourced so that the hypershift must-gather could pick up the args. This was removed in the refactor, breaking that collection. This restores the logic in a way that aligns with the refactor.

ref: https://issues.redhat.com/browse/ACM-16255

**Is this a Hub or Managed cluster change?:**

- [x] Hub Cluster
- [ ] Managed Cluster
- [ ] N/A