### PR TITLE
ACM-17867: fix hypershift dump to run only once

### DIFF
--- a/collection-scripts/gather_utils
+++ b/collection-scripts/gather_utils
@@ -93,7 +93,7 @@ extract_hypershift_cli() {
   fi
 
   # Extract the hypershift CLI from the hypershift operator pod
-  oc rsync -c operator ${HO_POD_NAME}:/usr/bin/hypershift /tmp
+  oc rsync -c operator -n hypershift ${HO_POD_NAME}:/usr/bin/hypershift /tmp
   chmod 755 /tmp/hypershift
   return 0
 }
@@ -110,6 +110,12 @@ dump_hostedcluster() {
     return 1
   fi
 
+  # This could be the second time to be here if both MCE and spoke gathers are run.
+  if [ -f $BASE_COLLECTION_PATH/hypershift-dump.tar.gz ]; then
+    log "Must-gather for hosted cluster \"$HC_NAME\" in namespace \"$HC_NAMESPACE\" has already been collected."
+    return 0
+  fi
+  
   if ! ensure_hypershift_cli; then
     log "ERROR" "Failed to find the hypershift CLI binary."
     return 1


### PR DESCRIPTION
**Related Issue:**
https://issues.redhat.com/browse/ACM-17867

**Description of Changes:**
Since an MCE cluster is also a self-managed spoke cluster (local-cluster), both mce and spoke gathers are run. They both runs the same hosted cluster dump. This change is to run the the hypershift dump only once in this case.

**What resource(s) are being added:**

**Is this a Hub or Managed cluster change?:**

- [ ] Hub Cluster
- [ ] Managed Cluster
- [ ] N/A

**Notes:**
