### PR TITLE
add DPA to acm hub log

### DIFF
--- a/collection-scripts/gather_hub_logs
+++ b/collection-scripts/gather_hub_logs
@@ -38,6 +38,7 @@ if [ -z $GATHER_HUB_RAN ] || [ $GATHER_HUB_RAN != true ]; then
   run_inspect ns/open-cluster-management-issuer
   run_inspect restores.cluster.open-cluster-management.io --all-namespaces
   run_inspect backupschedules.cluster.open-cluster-management.io --all-namespaces
+  run_inspect dataprotectionapplications.oadp.openshift.io --all-namespaces
   run_inspect backupstoragelocations.velero.io --all-namespaces
   run_inspect backups.velero.io --all-namespaces
   run_inspect restores.velero.io --all-namespaces


### PR DESCRIPTION
**Related Issue:**
https://issues.redhat.com/browse/ACM-17889

**Description of Changes:**
Updated gather_hub_logs and added 

  run_inspect dataprotectionapplications.oadp.openshift.io --all-namespaces


**What resource(s) are being added:**
dataprotectionapplications.oadp.openshift.io

**Is this a Hub or Managed cluster change?:**

- [x] Hub Cluster
- [ ] Managed Cluster
- [ ] N/A

**Notes:**
We want to push these changes to all supported ACM releases