### PR TITLE
Collect custom metrics, CMO and user workload configmaps

### DIFF
--- a/collection-scripts/gather_observability_logs
+++ b/collection-scripts/gather_observability_logs
@@ -18,4 +18,9 @@ if [[ -n "$MCO_NAME" ]]; then
     run_inspect multiclusterobservabilities.observability.open-cluster-management.io --all-namespaces
     run_inspect ns/open-cluster-management-observability
     run_inspect observatoria.core.observatorium.io --all-namespaces
+    # user workload metrics config
+    run_inspect configmap/observability-metrics-custom-allowlist --all-namespaces
+    # Cluster and user workload monitoring config for alert forwarding
+    run_inspect configmap/cluster-monitoring-config -n openshift-monitoring
+    run_inspect configmap/user-workload-monitoring-config -n openshift-user-workload-monitoring
 fi

--- a/collection-scripts/gather_spoke_logs
+++ b/collection-scripts/gather_spoke_logs
@@ -75,7 +75,10 @@ if oc get crd policies.policy.open-cluster-management.io &>/dev/null; then
     run_inspect "$i" --all-namespaces
   done
 
+  # Observability CRs
   run_inspect ns/open-cluster-management-addon-observability
+  run_inspect configmap/cluster-monitoring-config -n openshift-monitoring
+  run_inspect configmap/user-workload-monitoring-config -n openshift-user-workload-monitoring
 
   # VolSync CRs
   run_inspect replicationdestinations.volsync.backube --all-namespaces


### PR DESCRIPTION
**Related Issue:**
https://issues.redhat.com/browse/ACM-1951

**Description of Changes:**
Add missing Observability resources to must-gather collection

**What resource(s) are being added:**
```
configmap/observability-metrics-custom-allowlist --all-namespaces
configmap/cluster-monitoring-config -n openshift-monitoring
configmap/user-workload-monitoring-config -n openshift-user-workload-monitoring
```
**Is this a Hub or Managed cluster change?:**

- [x] Hub Cluster
- [x] Managed Cluster
- [ ] N/A

**Notes:**
