### PR TITLE
Add MulticlusterRoleAssignment to must-gather

### DIFF
--- a/collection-scripts/gather_hub_logs
+++ b/collection-scripts/gather_hub_logs
@@ -41,6 +41,9 @@ if [ -z $GATHER_HUB_RAN ] || [ $GATHER_HUB_RAN != true ]; then
   run_inspect ns/open-cluster-management-issuer
   run_inspect ansiblejobs.tower.ansible.com --all-namespaces
 
+  # Fine Grained RBAC CRs
+  run_inspect multiclusterroleassignments.rbac.open-cluster-management.io --all-namespaces
+
   # Backup and Restore chart,  OADP Operator and Velero CRs
   run_inspect restores.cluster.open-cluster-management.io --all-namespaces
   run_inspect backupschedules.cluster.open-cluster-management.io --all-namespaces


### PR DESCRIPTION

**Related Issue:**
https://issues.redhat.com/browse/ACM-24644

**Description of Changes:**
Add MulticlusterRoleAssignment tomust-gather. 

**What resource(s) are being added:**
MulticlusterRoleAssignment resources will create ClusterPermission resources which in turn creates the RBAC resources in the targeted managed clusters. MulticlusterRoleAssignment is namespaced scope **MulticlusterRoleAssignment is only used on hub**


**Is this a Hub or Managed cluster change?:**

- [x] Hub Cluster
- [ ] Managed Cluster
- [ ] N/A

**Notes:**
