### PR TITLE
fix: dumping hosted cluster content through the kube-apiserver service

### DIFF
--- a/collection-scripts/gather_utils
+++ b/collection-scripts/gather_utils
@@ -132,6 +132,6 @@ dump_hostedcluster() {
   fi
 
   log "Collecting must-gather for hosted cluster \"$HC_NAME\" in namespace \"$HC_NAMESPACE\""
-  ${HYPERSHIFT} dump cluster --dump-guest-cluster --artifact-dir $BASE_COLLECTION_PATH --name $HC_NAME --namespace $HC_NAMESPACE
+  ${HYPERSHIFT} dump cluster --dump-guest-cluster-through-kube-service --artifact-dir $BASE_COLLECTION_PATH --name $HC_NAME --namespace $HC_NAMESPACE
 }
 


### PR DESCRIPTION
A more direct aproach which still allows to dump hosted cluster content when debug handlers are disabled.

**Related Issue:**
ref: https://issues.redhat.com//browse/SREP-715

**Description of Changes:**
Debug handlers are disabled on Management Clusters (MCs) used in the scope of ROSA (formerly ROSA HCP). As a result it is not possible to "port-forward" `kube-apiserver` service port and target it.
A [new option](https://github.com/openshift/hypershift/pull/6533) has been added to the `hypershift` CLI for a more direct approach in which the `kube-apiserver` service is directly accessed.

**What resource(s) are being added:**

**Is this a Hub or Managed cluster change?:**

- [ ] Hub Cluster
- [X] Managed Cluster
- [ ] N/A

**Notes:**

Directly going through the `kube-apiserver` service comes with its own challenge and that's probably why it was "port-forward"ed in the first place:

`NetworkPolicies` may deny access to the `kube-apiserver` service.

That's not the case on MCs managed by us (i.e. scope: ROSA); but on Hypershift installations not managed by us this could be an issue. Hence the following question:

Is the `must-gather` image produced by this repository used outside of ROSA?

- If "no": this PR is just fine
- If "yes": we should find a way to switch between `--dump-guest-cluster` and `--dump-guest-cluster-through-kube-service` or, if not possible, try first to call the `hypershift` CLI with the current option and, in case of failure, with the new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated hosted cluster diagnostic data collection to use an alternative connectivity method, improving reliability of gathering cluster troubleshooting information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->