### PR TITLE
fix: use hypershift kube-apiserver as a fallback

### DIFF
--- a/collection-scripts/gather_utils
+++ b/collection-scripts/gather_utils
@@ -131,7 +131,13 @@ dump_hostedcluster() {
     return 1
   fi
 
-  log "Collecting must-gather for hosted cluster \"$HC_NAME\" in namespace \"$HC_NAMESPACE\""
-  ${HYPERSHIFT} dump cluster --dump-guest-cluster-through-kube-service --artifact-dir $BASE_COLLECTION_PATH --name $HC_NAME --namespace $HC_NAMESPACE
+  log "Collecting must-gather for hosted cluster '${HC_NAME}' in namespace '${HC_NAMESPACE}'"
+  hypershift_cmd=("${HYPERSHIFT}" dump cluster --artifact-dir "${BASE_COLLECTION_PATH}" --name "${HC_NAME}" --namespace "${HC_NAMESPACE}")
+  if ! "${hypershift_cmd[@]}" --dump-guest-cluster; then
+    log "WARN" "Failed to collect must-gather for hosted cluster '${HC_NAME}' in namespace '${HC_NAMESPACE}' using --dump-guest-cluster. Trying --dump-guest-cluster-through-kube-service."
+    if ! "${hypershift_cmd[@]}" --dump-guest-cluster-through-kube-service; then
+      log "ERROR" "Failed to collect must-gather for hosted cluster '${HC_NAME}' in namespace '${HC_NAMESPACE}' using --dump-guest-cluster-through-kube-service."
+      return 1
+    fi
+  fi
 }
-


### PR DESCRIPTION
Followup to:
- #730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosted-cluster diagnostics collection: the tool now attempts the primary collection method first, falls back to an alternative approach automatically if the initial attempt fails, and avoids redundant retries. Logging for warnings and errors has been clarified, and the command returns a non-zero exit on repeated failures to surface problems more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->