### PR TITLE
no-op rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,5 +125,5 @@ make build-and-run-image
 ```
 
 <!---
-Date: 04/10/2026
+Date: 04/13/2026
 -->


### PR DESCRIPTION
The previous `build_root` update to use `ubi-minimal` didn't work because it doesn't have `git`, which Prow needs to clone the repo. Testing whether changing it to the `stolostron` builder image resolves the `publish` job failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README metadata date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->