### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/build/Dockerfile.art
+++ b/build/Dockerfile.art
@@ -1,0 +1,52 @@
+ARG ACM_VERSION=${ACM_VERSION}
+
+# Copyright (c) 2021 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+FROM registry-proxy.engineering.redhat.com/openshift4/ose-cli-rhel9:latest AS oc-cli
+
+FROM registry-proxy.engineering.redhat.com/ubi9/go-toolset:latest AS hypershift-cli
+
+WORKDIR /hypershift
+COPY --chown=default external/hypershift .
+RUN make hypershift
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG ACM_VERSION
+
+ENV BASE_COLLECTION_PATH=/must-gather \
+    USER_UID=1001 \
+    USER_NAME=must-gather
+
+RUN microdnf install -y jq tar gzip rsync findutils
+
+# Copy binaries
+COPY --from=oc-cli /usr/bin/oc /usr/bin/oc
+
+# Copy hypershift CLI binary
+COPY --from=hypershift-cli /hypershift/bin/hypershift /usr/bin/hypershift
+
+# Copy license
+RUN mkdir licenses/
+COPY LICENSE licenses/
+
+# copy all collection scripts to /usr/bin
+COPY ./collection-scripts/* /usr/bin/
+
+# Setup non-root user
+COPY ./build/user_setup /usr/local/bin/
+RUN  /usr/local/bin/user_setup
+USER 1001
+
+ENTRYPOINT /usr/bin/gather
+
+LABEL name="rhacm2/acm-must-gather-rhel9"
+LABEL summary="Must-gather scripts for Red Hat Advanced Cluster Management"
+LABEL description="Must-gather scripts for Red Hat Advanced Cluster Management"
+LABEL io.k8s.display-name="ACM Must-gather"
+LABEL io.k8s.description="Must-gather scripts for Red Hat Advanced Cluster Management"
+LABEL com.redhat.component="acm-must-gather-container"
+LABEL io.openshift.tags="data,images"
+LABEL url="https://github.com/stolostron/must-gather"
+LABEL cpe="cpe:/a:redhat:acm:${ACM_VERSION}::el9"


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)