### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:latest AS hypershift-cli
 
 WORKDIR /hypershift
 COPY --chown=default external/hypershift .
-RUN make hypershift
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make hypershift
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847

**Related Issue:**

**Description of Changes:**

**What resource(s) are being added:**

**Is this a Hub or Managed cluster change?:**

- [ ] Hub Cluster
- [ ] Managed Cluster
- [ ] N/A

**Notes:**
