### PR TITLE
Add agent addon namespace for managed cluster in hosted mode (global …

### DIFF
--- a/collection-scripts/gather_hub_logs
+++ b/collection-scripts/gather_hub_logs
@@ -89,6 +89,7 @@ if [ -z $GATHER_HUB_RAN ] || [ $GATHER_HUB_RAN != true ]; then
 
   # Multicluster Global Hub Agent information
   run_inspect ns/multicluster-global-hub-agent
+  run_inspect ns/open-cluster-management-global-hub-agent-addon
 
   # Get disconnected information
   run_inspect imagecontentsourcepolicies.operator.openshift.io --all-namespaces


### PR DESCRIPTION
**Related Issue:**
Missing agent namsepace if hub is imported via hosted mode:
https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/multicluster_global_hub/multicluster-global-hub#global-hub-importing-hosted-mode

**Description of Changes:**
Add inspect of open-cluster-management-global-hub-agent-addon namespace 

**What resource(s) are being added:**

**Is this a Hub or Managed cluster change?:**

- [ ] Hub Cluster
- [X] Managed Cluster
- [ ] N/A

**Notes:**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded spoke logs collection to include logs from an additional source, improving diagnostic coverage for troubleshooting purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->