### PR TITLE
fix(gather): always collect observability resources on spoke clusters

### DIFF
--- a/collection-scripts/gather_spoke_logs
+++ b/collection-scripts/gather_spoke_logs
@@ -44,8 +44,32 @@ gather_spoke() {
   run_inspect ns/openshift-operators # gatekeeper and volsync operator will be installed in this ns in production
 }
 
+gather_observability() {
+  log "Gathering Observability resources"
+  run_inspect ns/open-cluster-management-addon-observability
+
+  # user workload metrics config - collect observability-metrics-custom-allowlist across all namespaces
+  OBSERVABILITY_NAMESPACES=$(oc get configmap --all-namespaces --field-selector=metadata.name=observability-metrics-custom-allowlist -o jsonpath='{.items[*].metadata.namespace}')
+  for namespace in ${OBSERVABILITY_NAMESPACES}; do
+    run_inspect configmap/observability-metrics-custom-allowlist -n "${namespace}"
+  done
+
+  # MCOA resources
+  for addon_namespace in ${CUSTOMIZED_ADDON_NAMESPACES}; do
+    run_inspect prometheusagents.monitoring.rhobs -n "$addon_namespace"
+    run_inspect prometheusrules.monitoring.coreos.com -n "$addon_namespace"
+  done
+  run_inspect scrapeconfigs.monitoring.rhobs --all-namespaces
+  run_inspect ns/openshift-cluster-observability-operator
+
+  # Cluster and user workload monitoring config for alert forwarding
+  run_inspect configmap/cluster-monitoring-config -n openshift-monitoring
+  run_inspect configmap/user-workload-monitoring-config -n openshift-user-workload-monitoring
+}
+
 log "Starting Managed cluster must-gather"
 gather_spoke
+gather_observability
 parse_args "$@"
 dump_hostedcluster
 
@@ -75,26 +99,6 @@ if oc get crd policies.policy.open-cluster-management.io &>/dev/null; then
   for i in $(oc get crds -o custom-columns=NAME:.metadata.name | grep '\.gatekeeper\.sh$'); do
     run_inspect "$i" --all-namespaces
   done
-
-  # Observability CRs
-  run_inspect ns/open-cluster-management-addon-observability
-  # user workload metrics config - collect observability-metrics-custom-allowlist across all namespaces
-  OBSERVABILITY_NAMESPACES=$(oc get configmap --all-namespaces --field-selector=metadata.name=observability-metrics-custom-allowlist -o jsonpath='{.items[*].metadata.namespace}')
-  for namespace in ${OBSERVABILITY_NAMESPACES}; do
-    run_inspect configmap/observability-metrics-custom-allowlist -n "${namespace}"
-  done
-  # MCOA resources
-  for addon_namespace in ${CUSTOMIZED_ADDON_NAMESPACES}; do
-    run_inspect prometheusagents.monitoring.rhobs -n "$addon_namespace"
-    run_inspect prometheusrules.monitoring.coreos.com -n "$addon_namespace"
-  done
-  run_inspect scrapeconfigs.monitoring.rhobs --all-namespaces
-  run_inspect ns/openshift-cluster-observability-operator
-
-  # Cluster and user workload monitoring config for alert forwarding
-  run_inspect configmap/cluster-monitoring-config -n openshift-monitoring
-  run_inspect configmap/user-workload-monitoring-config -n openshift-user-workload-monitoring
-
 
   # VolSync CRs
   run_inspect replicationdestinations.volsync.backube --all-namespaces


### PR DESCRIPTION
## Summary

Move all observability-related spoke collection out of the ACM policies CRD
conditional block into a new `gather_observability()` function that runs
unconditionally on every spoke cluster.

## Root Cause

In `gather_spoke_logs`, observability resources were collected inside the
`if oc get crd policies.policy.open-cluster-management.io` block. This CRD
check was introduced in commit `46a7356` (2023 re-architecture) as a heuristic
for "ACM vs MCE-only" — not as a policy-specific guard. The old monolithic
`gather_spoke()` had no conditional checks at all; everything was gathered
unconditionally. During the split, all non-MCE resources were placed behind
the policy CRD check, and subsequent contributors followed the pattern.

Observability components have no dependency on the GRC policy framework. A spoke
cluster with observability enabled but without the policy CRD (e.g. GRC addon
disabled) would skip collecting these resources entirely.

## Fix

Created `gather_observability()` function called unconditionally after
`gather_spoke()`. Resources moved:

- `ns/open-cluster-management-addon-observability`
- `observability-metrics-custom-allowlist` configmaps (all namespaces)
- MCOA resources (`prometheusagents`, `prometheusrules`, `scrapeconfigs`)
- `ns/openshift-cluster-observability-operator`
- `cluster-monitoring-config` and `user-workload-monitoring-config` configmaps

Note: `run_inspect` is a thin wrapper around `oc adm inspect` with no `set -e`,
so missing resources are handled gracefully (logged and skipped). The CRD guard
was never needed for correctness.

## Testing

- [x] ShellCheck passes on the changed file
- [ ] Verified on a spoke cluster with observability enabled but without ACM policies CRD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spoke log collection now consistently gathers observability-related resources immediately after the main spoke logs are collected.
  * Observability collection no longer depends on the presence of specific managed-cluster CRDs, preventing scenarios where observability logs could be unintentionally skipped.
  * The observability add-on namespace and relevant allowlisted metrics/config resources are included as part of the standard collection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->